### PR TITLE
Resize canvas according to window

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "sbt-derivation": "sbt-derivation"
       },
       "locked": {
-        "lastModified": 1734944021,
-        "narHash": "sha256-PP22iPfYxsNeGCTbSTkQ2OmUNdWqaJ18W+EsDuHaI7Q=",
+        "lastModified": 1735541734,
+        "narHash": "sha256-bGwTLN7oI3eyqtIyt50T8atAn7bVoHR819RgBzTVeIs=",
         "owner": "jiribenes",
         "repo": "effekt-nix",
-        "rev": "f107d07152187b71c133e08b383407977757e798",
+        "rev": "33be6781cc510f0459877e6704eb983ed0d16b57",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734856068,
-        "narHash": "sha256-Q+CB1ajsJg4Z9HGHTBAGY1q18KpnnkmF/eCTLUY6FQ0=",
+        "lastModified": 1735523292,
+        "narHash": "sha256-opBsbR/nrGxiiF6XzlVluiHYb6yN/hEwv+lBWTy9xoM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93ff48c9be84a76319dac293733df09bbbe3f25c",
+        "rev": "6d97d419e5a9b36e6293887a89a078cf85f5a61b",
         "type": "github"
       },
       "original": {

--- a/src/ffi.effekt
+++ b/src/ffi.effekt
@@ -64,15 +64,15 @@ extern io def resizeCanvas(width: Int, height: Int): Context2D =
   """
 
 extern io def drawRect(
-  ctx: Context2D, x: Double, y: Double, 
-  width: Double, height: Double, color: String
+  ctx: Context2D, x: Int, y: Int, 
+  width: Int, height: Int, color: String
 ): Unit =
   jsWeb """${ctx}.fillStyle = ${color}; 
            ${ctx}.fillRect(${x}, ${y}, ${width}, ${height});"""
 
 extern io def drawCircle(
-  ctx: Context2D, x: Double, y: Double, 
-  radius: Double, color: String
+  ctx: Context2D, x: Int, y: Int, 
+  radius: Int, color: String
 ): Unit =
   jsWeb """${ctx}.fillStyle = ${color};
            ${ctx}.beginPath();
@@ -87,7 +87,7 @@ extern io def clear(ctx: Context2D): Unit =
 
 extern io def drawText(
   ctx: Context2D, text: String,
-  x: Double, y: Double, font: String, 
+  x: Int, y: Int, font: String, 
   alignment: String, baseline: String, color: String
 ): Unit =
   jsWeb """${ctx}.font = ${font};
@@ -100,7 +100,7 @@ extern io def drawText(
 //relative to the given coordinates
 extern io def setupRotation(
   ctx: Context2D, angle: Double, 
-  relativeToX: Double, relativeToY: Double
+  relativeToX: Int, relativeToY: Int
 ): Unit =
   jsWeb """${ctx}.translate(${relativeToX}, ${relativeToY});
            ${ctx}.rotate(${angle});

--- a/src/ffi.effekt
+++ b/src/ffi.effekt
@@ -16,7 +16,7 @@ def getElementById(id: String): Option[Node] = {
 extern type Event
 
 extern io def addEventListener(eventType: String, callback: Event => Unit at {io, global}): Unit =
-  jsWeb """document.addEventListener(${eventType}, 
+  jsWeb """document.defaultView.addEventListener(${eventType}, 
            (event) => $effekt.runToplevel((ks, k) => ${callback}(event, ks, k)))"""
 
 extern pure def getKey(event: Event): String =
@@ -32,7 +32,7 @@ extern io def getButton(event: Event): Int =
   jsWeb "${event}.button"
 
 
-extern io def createCanvas(width: Double, height: Double): Node =
+extern io def createCanvas(width: Int, height: Int): Node =
   jsWeb """(function(){
   canvas = document.createElement("canvas");
   canvas.id = "canvas";
@@ -44,6 +44,10 @@ extern io def createCanvas(width: Double, height: Double): Node =
   return canvas;
   })()
   """
+
+extern io def resize(canvas: Node, width: Int, height: Int): Unit =
+  jsWeb """canvas.width = ${width}
+           canvas.height = ${height}"""
 
 extern io def drawRect(
   canvas: Node, x: Double, y: Double, 
@@ -102,3 +106,8 @@ extern io def requestIdleCallback(callback: (IdleDeadline) => Unit at {io, globa
   jsWeb "window.requestIdleCallback(deadline => $effekt.runToplevel((ks, k) => ${callback}(deadline, ks, k)))"
 
 extern io def getTime(): Int = jsWeb "Date.now()"
+
+extern pure def innerWidth(): Int = 
+    jsWeb "window.innerWidth"
+extern pure def innerHeight(): Int = 
+  jsWeb "window.innerHeight"

--- a/src/ffi.effekt
+++ b/src/ffi.effekt
@@ -45,8 +45,9 @@ extern io def createCanvas(width: Int, height: Int): Context2D =
   canvas.height = ${height};
   //https://stackoverflow.com/a/7782251/15982248
   canvas.style.position = "absolute";
-  canvas.style.top = 0;
-  canvas.style.left = 0;
+  canvas.style.top = '50%';
+  canvas.style.left = '50%';
+  canvas.style.transform = 'translate(-50%, -50%)';
   canvas.style.setProperty("image-rendering", "pixelated");
   $resize(canvas, ${width}, ${height});
   document.body.appendChild(canvas);

--- a/src/ffi.effekt
+++ b/src/ffi.effekt
@@ -3,16 +3,6 @@ module ffi
 extern def toDouble(b: Bool): Double = 
   js "(function() { if (${b}) { return 1; } else { return 0; }})()"
 
-extern type Node
-
-extern io def unsafeGetElementById(id: String): Node =
-  jsWeb "document.getElementById(${id})"
-
-def getElementById(id: String): Option[Node] = {
-  val unsafeElement = unsafeGetElementById(id)
-  undefinedToOption(unsafeElement)
-}
-
 extern type Event
 
 extern io def addEventListener(eventType: String, callback: Event => Unit at {io, global}): Unit =
@@ -31,74 +21,97 @@ extern io def getClientY(event: Event): Double =
 extern io def getButton(event: Event): Int =
   jsWeb "${event}.button"
 
+extern type Context2D
 
-extern io def createCanvas(width: Int, height: Int): Node =
+extern jsWeb """
+  function get$canvas() {
+    return document.getElementById("canvas")
+  }
+
+  function $resize(canvas, width, height) {
+    canvas.style.width = width + "px";
+    canvas.style.height = height + "px";
+    ctx = canvas.getContext("2d");
+    ctx.imageSmoothingEnabled = false;
+    return ctx;
+  }
+"""
+
+extern io def createCanvas(width: Int, height: Int): Context2D =
   jsWeb """(function(){
   canvas = document.createElement("canvas");
   canvas.id = "canvas";
   canvas.width = ${width};
   canvas.height = ${height};
   //https://stackoverflow.com/a/7782251/15982248
-  canvas.style = "position:absolute;top:0;left:0";
+  canvas.style.position = "absolute";
+  canvas.style.top = 0;
+  canvas.style.left = 0;
+  canvas.style.setProperty("image-rendering", "pixelated");
+  $resize(canvas, ${width}, ${height});
   document.body.appendChild(canvas);
-  return canvas;
+  return ctx;
   })()
   """
 
-extern io def resize(canvas: Node, width: Int, height: Int): Unit =
-  jsWeb """canvas.width = ${width}
-           canvas.height = ${height}"""
+///https://www.youtube.com/watch?v=1y57COMRSdA
+extern io def resizeCanvas(width: Int, height: Int): Context2D =
+  jsWeb """(function(){
+  canvas = get$canvas();
+  return $resize(canvas, ${width}, ${height});
+  })()
+  """
 
 extern io def drawRect(
-  canvas: Node, x: Double, y: Double, 
+  ctx: Context2D, x: Double, y: Double, 
   width: Double, height: Double, color: String
 ): Unit =
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.fillStyle = ${color}; 
-           ctx.fillRect(${x}, ${y}, ${width}, ${height});"""
+  jsWeb """${ctx}.fillStyle = ${color}; 
+           ${ctx}.fillRect(${x}, ${y}, ${width}, ${height});"""
 
-extern io def drawCircle(canvas: Node, x: Double, y: Double, radius: Double, color: String): Unit =
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.fillStyle = ${color};
-           ctx.beginPath();
-           ctx.arc(${x}, ${y}, ${radius}, 0, 2 * Math.PI);
-           ctx.fill();"""
+extern io def drawCircle(
+  ctx: Context2D, x: Double, y: Double, 
+  radius: Double, color: String
+): Unit =
+  jsWeb """${ctx}.fillStyle = ${color};
+           ${ctx}.beginPath();
+           ${ctx}.arc(${x}, ${y}, ${radius}, 0, 2 * Math.PI);
+           ${ctx}.fill();"""
 
-extern io def clear(canvas: Node): Unit = 
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           w = ${canvas}.width;
-           h = ${canvas}.height;
-           ctx.clearRect(0, 0, w, h)"""
+extern io def clear(ctx: Context2D): Unit = 
+  jsWeb """canvas = get$canvas();
+           w = canvas.width;
+           h = canvas.height;
+           ${ctx}.clearRect(0, 0, w, h)"""
 
 extern io def drawText(
-  canvas: Node, text: String,
+  ctx: Context2D, text: String,
   x: Double, y: Double, font: String, 
   alignment: String, baseline: String, color: String
 ): Unit =
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.font = ${font};
-           ctx.textAlign = ${alignment};
-           ctx.textBaseline = ${baseline};
-           ctx.fillStyle = ${color};
-           ctx.fillText(${text}, ${x}, ${y})"""
+  jsWeb """${ctx}.font = ${font};
+           ${ctx}.textAlign = ${alignment};
+           ${ctx}.textBaseline = ${baseline};
+           ${ctx}.fillStyle = ${color};
+           ${ctx}.fillText(${text}, ${x}, ${y})"""
 
 //Sets up the transformation matrix to rotate all later drawn shapes clockwise by the given angle 
 //relative to the given coordinates
-extern io def setupRotation(canvas: Node, angle: Double, relativeToX: Double, relativeToY: Double): Unit =
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.translate(${relativeToX}, ${relativeToY});
-           ctx.rotate(${angle});
-           ctx.translate(-${relativeToX}, -${relativeToY});"""
+extern io def setupRotation(
+  ctx: Context2D, angle: Double, 
+  relativeToX: Double, relativeToY: Double
+): Unit =
+  jsWeb """${ctx}.translate(${relativeToX}, ${relativeToY});
+           ${ctx}.rotate(${angle});
+           ${ctx}.translate(-${relativeToX}, -${relativeToY});"""
 
 extern type DOMMatrix
 
-extern io def getTransform(canvas: Node): DOMMatrix = 
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.getTransform();"""
+extern io def getTransform(ctx: Context2D): DOMMatrix = 
+  jsWeb "${ctx}.getTransform();"
 
-extern io def setTransform(canvas: Node, matrix: DOMMatrix): Unit =
-  jsWeb """ctx = ${canvas}.getContext("2d");
-           ctx.setTransform(${matrix});"""
+extern io def setTransform(ctx: Context2D, matrix: DOMMatrix): Unit =
+  jsWeb "${ctx}.setTransform(${matrix});"
 
 extern type IdleDeadline
 
@@ -107,7 +120,8 @@ extern io def requestIdleCallback(callback: (IdleDeadline) => Unit at {io, globa
 
 extern io def getTime(): Int = jsWeb "Date.now()"
 
-extern pure def innerWidth(): Int = 
-    jsWeb "window.innerWidth"
-extern pure def innerHeight(): Int = 
+extern io def windowWidth(): Int = 
+  jsWeb "window.innerWidth"
+
+extern io def windowHeight(): Int =
   jsWeb "window.innerHeight"

--- a/src/game/constants.effekt
+++ b/src/game/constants.effekt
@@ -12,6 +12,14 @@ import src/vec2d
 
 val ASPECT_RATIO = 16.0 / 9.0
 
+def fittingSizes(width: Int, height: Int): (Int, Int) = {
+  if(height.toDouble * ASPECT_RATIO > width.toDouble) {
+    (width, (width.toDouble / ASPECT_RATIO).toInt)
+  } else {
+    ((height.toDouble * ASPECT_RATIO).toInt, height)
+  }
+}
+
 val GAME_WIDTH = 384
 val GAME_HEIGHT = (GAME_WIDTH.toDouble / ASPECT_RATIO).toInt()
 val GAME_CENTER = fromInt(GAME_WIDTH / 2, GAME_HEIGHT / 2)

--- a/src/game/constants.effekt
+++ b/src/game/constants.effekt
@@ -17,6 +17,11 @@ interface Screen {
 def screenCenter(): Vec2d / Screen = 
   Vec2d(do width().toDouble / 2.0, do height().toDouble / 2.0)
 
+val ASPECT_RATIO = 16.0 / 9.0
+
+val GAME_WIDTH = 384
+val GAME_HEIGHT = (GAME_WIDTH.toDouble / ASPECT_RATIO).toInt()
+
 val SECOND_IN_MS = 1000
 
 //------------------- Events -------------------

--- a/src/game/constants.effekt
+++ b/src/game/constants.effekt
@@ -9,6 +9,14 @@ import src/text
 import src/utils
 import src/vec2d
 
+interface Screen {
+  def width(): Int
+  def height(): Int
+}
+
+def screenCenter(): Vec2d / Screen = 
+  Vec2d(do width().toDouble / 2.0, do height().toDouble / 2.0)
+
 val SECOND_IN_MS = 1000
 
 //------------------- Events -------------------
@@ -16,38 +24,30 @@ val KEY_DOWN = "keydown"
 val KEY_UP = "keyup"
 val MOUSE_MOVE = "mousemove"
 val MOUSE_DOWN = "mousedown"
+val RESIZE = "resize"
 
 //------------------- GameState -------------------
-namespace externVal {
-  extern pure def clientWidth(): Double = 
-    jsWeb "document.documentElement.clientWidth"
-  extern pure def clientHeight(): Double = 
-    jsWeb "document.documentElement.clientHeight"
-}
-
-val CANVAS_WIDTH = externVal::clientWidth()
-val CANVAS_HEIGHT = externVal::clientHeight()
-val CANVAS_CENTER = Vec2d(CANVAS_WIDTH / 2.0, CANVAS_HEIGHT / 2.0)
-
 val CANVAS_PLAYER_FACTOR = 15.0
-val PLAYER_SIZE = CANVAS_HEIGHT / CANVAS_PLAYER_FACTOR
 val PLAYER_START_SPEED = 0.4
 val PLAYER_START_HEALTH = 2
-val PLAYER_START_POS = CANVAS_CENTER
-val PLAYER_HITBOX = Circle(PLAYER_START_POS, PLAYER_SIZE, Green())
-
 val PLAYER_GUN_FACTOR = 1.2
-val GUN_WIDTH  = PLAYER_SIZE / PLAYER_GUN_FACTOR
 val GUN_WIDTH_HEIGHT_FACTOR = 3.0
-val GUN_HEIGTH = GUN_WIDTH / GUN_WIDTH_HEIGHT_FACTOR
-val GUN_START_POS = PLAYER_START_POS + Vec2d(PLAYER_SIZE - 1.0, -0.5 * GUN_HEIGTH)
-val GUN = Rect(GUN_START_POS, GUN_WIDTH, GUN_HEIGTH, Black())
-val START_PLAYER = Player(
-  PLAYER_HITBOX,
-  GUN,
-  PLAYER_START_HEALTH, 
-  PLAYER_START_SPEED
-)
+def startPlayer(): Player / Screen = {
+  val PLAYER_SIZE = do height().toDouble() / CANVAS_PLAYER_FACTOR
+  val PLAYER_START_POS = screenCenter()
+  val PLAYER_HITBOX = Circle(PLAYER_START_POS, PLAYER_SIZE, Green())
+  val GUN_WIDTH  = PLAYER_SIZE / PLAYER_GUN_FACTOR
+  val GUN_HEIGTH = GUN_WIDTH / GUN_WIDTH_HEIGHT_FACTOR
+  val GUN_START_POS = PLAYER_START_POS + Vec2d(PLAYER_SIZE - 1.0, -0.5 * GUN_HEIGTH)
+  val GUN = Rect(GUN_START_POS, GUN_WIDTH, GUN_HEIGTH, Black())
+  val START_PLAYER = Player(
+    PLAYER_HITBOX,
+    GUN,
+    PLAYER_START_HEALTH, 
+    PLAYER_START_SPEED
+  )
+  START_PLAYER
+}
 
 val CANVAS_ZOMBIE_FACTOR = CANVAS_PLAYER_FACTOR
 val ZOMBIE_BASE_SPEED = 0.3
@@ -64,18 +64,22 @@ val START_TIMERS = GameTimer(
   Timer(START_WAVE_TIMER)
 )
 
-val START_GAME = GameState(START_PLAYER, [], START_TIMERS, START_WAVE, START_SCORE)
+def startGame(): GameState / Screen =
+  GameState(startPlayer(), [], START_TIMERS, START_WAVE, START_SCORE)
 
 //------------------- UI -------------------
 val CANVAS_RETRY_WIDTH_FACTOR = 4.0
-val RETRY_BUTTON_WIDTH = CANVAS_WIDTH / CANVAS_RETRY_WIDTH_FACTOR
 val CANVAS_RETRY_HEIGHT_FACTOR = 6.0
-val RETRY_BUTTON_HEIGHT = CANVAS_HEIGHT / CANVAS_RETRY_HEIGHT_FACTOR
-val RETRY_BUTTON_CENTER = CANVAS_CENTER + fromInt(0, 50)
-val RETRY_BUTTON = Rect(
-  NULL_VECTOR, RETRY_BUTTON_WIDTH,
-  RETRY_BUTTON_HEIGHT, Green()
-).centerAt(RETRY_BUTTON_CENTER)
-val RETRY_TEXT = Text(
-  "Retry", RETRY_BUTTON_CENTER, 64, Serif(), Center(), Middle(), White()
-)
+def retryButton(): (SimpleDrawable, Text) / Screen = {
+  val RETRY_BUTTON_WIDTH = do width().toDouble / CANVAS_RETRY_WIDTH_FACTOR
+  val RETRY_BUTTON_HEIGHT = do height().toDouble / CANVAS_RETRY_HEIGHT_FACTOR
+  val RETRY_BUTTON_CENTER = screenCenter() + fromInt(0, 50)
+  val RETRY_BUTTON = Rect(
+    NULL_VECTOR, RETRY_BUTTON_WIDTH,
+    RETRY_BUTTON_HEIGHT, Green()
+  ).centerAt(RETRY_BUTTON_CENTER)
+  val RETRY_TEXT = Text(
+    "Retry", RETRY_BUTTON_CENTER, 64, Serif(), Center(), Middle(), White()
+  )
+  (RETRY_BUTTON, RETRY_TEXT)
+}

--- a/src/game/constants.effekt
+++ b/src/game/constants.effekt
@@ -5,22 +5,16 @@ import src/game/gamestate
 import src/game/gametimer
 import src/game/player
 import src/shapes/simple
+import src/shapes/manipulated
 import src/text
 import src/utils
 import src/vec2d
-
-interface Screen {
-  def width(): Int
-  def height(): Int
-}
-
-def screenCenter(): Vec2d / Screen = 
-  Vec2d(do width().toDouble / 2.0, do height().toDouble / 2.0)
 
 val ASPECT_RATIO = 16.0 / 9.0
 
 val GAME_WIDTH = 384
 val GAME_HEIGHT = (GAME_WIDTH.toDouble / ASPECT_RATIO).toInt()
+val GAME_CENTER = fromInt(GAME_WIDTH / 2, GAME_HEIGHT / 2)
 
 val SECOND_IN_MS = 1000
 
@@ -33,29 +27,28 @@ val RESIZE = "resize"
 
 //------------------- GameState -------------------
 val CANVAS_PLAYER_FACTOR = 15.0
-val PLAYER_START_SPEED = 0.4
+val PLAYER_START_SPEED = GAME_WIDTH.toDouble / (3 * SECOND_IN_MS).toDouble
 val PLAYER_START_HEALTH = 2
 val PLAYER_GUN_FACTOR = 1.2
 val GUN_WIDTH_HEIGHT_FACTOR = 3.0
-def startPlayer(): Player / Screen = {
-  val PLAYER_SIZE = do height().toDouble() / CANVAS_PLAYER_FACTOR
-  val PLAYER_START_POS = screenCenter()
-  val PLAYER_HITBOX = Circle(PLAYER_START_POS, PLAYER_SIZE, Green())
-  val GUN_WIDTH  = PLAYER_SIZE / PLAYER_GUN_FACTOR
-  val GUN_HEIGTH = GUN_WIDTH / GUN_WIDTH_HEIGHT_FACTOR
-  val GUN_START_POS = PLAYER_START_POS + Vec2d(PLAYER_SIZE - 1.0, -0.5 * GUN_HEIGTH)
-  val GUN = Rect(GUN_START_POS, GUN_WIDTH, GUN_HEIGTH, Black())
-  val START_PLAYER = Player(
-    PLAYER_HITBOX,
-    GUN,
-    PLAYER_START_HEALTH, 
-    PLAYER_START_SPEED
-  )
-  START_PLAYER
-}
+val PLAYER_SIZE = GAME_HEIGHT.toDouble() / CANVAS_PLAYER_FACTOR
+val PLAYER_START_POS = GAME_CENTER
+val PLAYER_HITBOX = Circle(PLAYER_START_POS, PLAYER_SIZE, Green())
+val GUN_WIDTH  = PLAYER_SIZE / PLAYER_GUN_FACTOR
+val GUN_HEIGTH = GUN_WIDTH / GUN_WIDTH_HEIGHT_FACTOR
+val GUN_START_POS = PLAYER_START_POS + Vec2d(PLAYER_SIZE - 1.0, -0.5 * GUN_HEIGTH)
+val GUN = Rect(GUN_START_POS, GUN_WIDTH, GUN_HEIGTH, Black())
+val START_PLAYER = Player(
+  PLAYER_HITBOX,
+  GUN,
+  PLAYER_START_HEALTH, 
+  PLAYER_START_SPEED
+)
+
+val BULLET_SPEED = GAME_WIDTH.toDouble / SECOND_IN_MS.toDouble
 
 val CANVAS_ZOMBIE_FACTOR = CANVAS_PLAYER_FACTOR
-val ZOMBIE_BASE_SPEED = 0.3
+val ZOMBIE_BASE_SPEED = GAME_WIDTH.toDouble / (10 * SECOND_IN_MS).toDouble
 
 val START_WAVE = 1
 val START_WAVE_TIMER = 10
@@ -69,22 +62,35 @@ val START_TIMERS = GameTimer(
   Timer(START_WAVE_TIMER)
 )
 
-def startGame(): GameState / Screen =
-  GameState(startPlayer(), [], START_TIMERS, START_WAVE, START_SCORE)
+val START_GAME = GameState(START_PLAYER, [], START_TIMERS, START_WAVE, START_SCORE)
 
 //------------------- UI -------------------
+val DEATH_BACKGROUND = 
+  Simple(Rect(NULL_VECTOR, GAME_WIDTH.toDouble, GAME_HEIGHT.toDouble, Black()))
+
+val YOU_DIED_OFFSET = GAME_HEIGHT / 8 
+val YOU_DIED_SIZE = GAME_HEIGHT / 9 
+val YOU_DIED = Text(
+  "You Died",
+  GAME_CENTER - fromInt(0, YOU_DIED_OFFSET),
+  YOU_DIED_SIZE,
+  Serif(),
+  Center(),
+  Bottom(),
+  Red()
+)
 val CANVAS_RETRY_WIDTH_FACTOR = 4.0
 val CANVAS_RETRY_HEIGHT_FACTOR = 6.0
-def retryButton(): (SimpleDrawable, Text) / Screen = {
-  val RETRY_BUTTON_WIDTH = do width().toDouble / CANVAS_RETRY_WIDTH_FACTOR
-  val RETRY_BUTTON_HEIGHT = do height().toDouble / CANVAS_RETRY_HEIGHT_FACTOR
-  val RETRY_BUTTON_CENTER = screenCenter() + fromInt(0, 50)
-  val RETRY_BUTTON = Rect(
-    NULL_VECTOR, RETRY_BUTTON_WIDTH,
-    RETRY_BUTTON_HEIGHT, Green()
-  ).centerAt(RETRY_BUTTON_CENTER)
-  val RETRY_TEXT = Text(
-    "Retry", RETRY_BUTTON_CENTER, 64, Serif(), Center(), Middle(), White()
-  )
-  (RETRY_BUTTON, RETRY_TEXT)
-}
+val RETRY_BUTTON_WIDTH = GAME_WIDTH.toDouble / CANVAS_RETRY_WIDTH_FACTOR
+val RETRY_BUTTON_HEIGHT = GAME_HEIGHT.toDouble / CANVAS_RETRY_HEIGHT_FACTOR
+val RETRY_BUTTON_CENTER = GAME_CENTER + fromInt(0, 50)
+val RETRY_BUTTON = Rect(
+  NULL_VECTOR, RETRY_BUTTON_WIDTH,
+  RETRY_BUTTON_HEIGHT, Green()
+).centerAt(RETRY_BUTTON_CENTER)
+
+val RETRY_TEXT_WIDTH = 128.0 / CANVAS_RETRY_HEIGHT_FACTOR
+val RETRY_TEXT = Text(
+  "Retry", RETRY_BUTTON_CENTER, RETRY_TEXT_WIDTH.toInt(), 
+  Serif(), Center(), Middle(), White()
+)

--- a/src/game/game.effekt
+++ b/src/game/game.effekt
@@ -24,17 +24,14 @@ interface Input {
   def mousePos(): Vec2d
 }
 
-interface Screen {
-  def width(): Double
-  def height(): Double
-}
-
 def visible(d: ManipulatedDrawable): Bool / Screen = 
-  collides(d, Simple(Rect(NULL_VECTOR, do width(), do height(), Black())))
+  collides(
+    d, Simple(Rect(NULL_VECTOR, do width().toDouble, do height().toDouble, Black()))
+  )
 
 def keepInsideScreen(player: Player): Player / Screen = {
-  val screenW = do width()
-  val screenH = do height()
+  val screenW = do width().toDouble
+  val screenH = do height().toDouble
   val playerCenter = player.drawable.getCenter()
   val centerInside = Vec2d(
     playerCenter.x.clamp(0.0, screenW),
@@ -59,8 +56,8 @@ type Side {
 val SIDES = [Top(), Right(), Bottom(), Left()]
 
 def spawnZombie(game: GameState): GameObject / { Screen, random } = {
-  val w = do width()
-  val h = do height()
+  val w = do width().toDouble
+  val h = do height().toDouble
   val totalScreenEdge = 2.0 * w + 2.0 * h
   val sideProbs = [w, h, w, h].map {side => side / totalScreenEdge}
   val spawnSide = SIDES.choose(sideProbs).getOrElse{Right()}
@@ -193,8 +190,8 @@ def render(game: GameState): Unit / { Canvas, Input } = {
 }
 
 def renderDeathScreen(): Unit / { Canvas, Screen } = {
-  val w = do width()
-  val h = do height()
+  val w = do width().toDouble
+  val h = do height().toDouble
   val center = Vec2d(w / 2.0, h / 2.0)
 
   val background = Simple(Rect(NULL_VECTOR, w, h, Black()))

--- a/src/game/game.effekt
+++ b/src/game/game.effekt
@@ -24,14 +24,14 @@ interface Input {
   def mousePos(): Vec2d
 }
 
-def visible(d: ManipulatedDrawable): Bool / Screen = 
+def visible(d: ManipulatedDrawable): Bool = 
   collides(
-    d, Simple(Rect(NULL_VECTOR, do width().toDouble, do height().toDouble, Black()))
+    d, Simple(Rect(NULL_VECTOR, GAME_WIDTH.toDouble, GAME_HEIGHT.toDouble, Black()))
   )
 
-def keepInsideScreen(player: Player): Player / Screen = {
-  val screenW = do width().toDouble
-  val screenH = do height().toDouble
+def keepInsideScreen(player: Player): Player = {
+  val screenW = GAME_WIDTH.toDouble
+  val screenH = GAME_HEIGHT.toDouble
   val playerCenter = player.drawable.getCenter()
   val centerInside = Vec2d(
     playerCenter.x.clamp(0.0, screenW),
@@ -55,9 +55,9 @@ type Side {
 
 val SIDES = [Top(), Right(), Bottom(), Left()]
 
-def spawnZombie(game: GameState): GameObject / { Screen, random } = {
-  val w = do width().toDouble
-  val h = do height().toDouble
+def spawnZombie(game: GameState): GameObject / random = {
+  val w = GAME_WIDTH.toDouble
+  val h = GAME_HEIGHT.toDouble
   val totalScreenEdge = 2.0 * w + 2.0 * h
   val sideProbs = [w, h, w, h].map {side => side / totalScreenEdge}
   val spawnSide = SIDES.choose(sideProbs).getOrElse{Right()}
@@ -97,7 +97,7 @@ def move(player: Player, dt: Int): Player / Input = {
   )
 }
 
-def shooting(objects: List[GameObject]): (List[GameObject], Int, Bool) / Screen = {
+def shooting(objects: List[GameObject]): (List[GameObject], Int, Bool) = {
   val (inRange, outOfRange) = objects.partition {
     case Bullet(hitbox, _) => hitbox.visible()
     case _ => true
@@ -129,7 +129,7 @@ def shooting(objects: List[GameObject]): (List[GameObject], Int, Bool) / Screen 
   (alive.append(remainingBullets), dead.size, outOfRange.nonEmpty)
 }
 
-def update(game: GameState, dt: Int): GameState / { Input, random, Screen } = {
+def update(game: GameState, dt: Int): GameState / { Input, random } = {
   val player = game.player
   val movedPlayer = player.move(dt)
   val objects = game.objects
@@ -189,23 +189,9 @@ def render(game: GameState): Unit / { Canvas, Input } = {
   game.objects.foreach { o => do draw(o.getHitbox()) }
 }
 
-def renderDeathScreen(): Unit / { Canvas, Screen } = {
-  val w = do width().toDouble
-  val h = do height().toDouble
-  val center = Vec2d(w / 2.0, h / 2.0)
-
-  val background = Simple(Rect(NULL_VECTOR, w, h, Black()))
-
-  val YOU_DIED = Text(
-    "You Died",
-    center - fromInt(0, 100),
-    48,
-    Serif(),
-    Center(),
-    Bottom(),
-    Red()
-  )
-
-  do draw(background)
+def renderDeathScreen(): Unit / Canvas = {
+  do draw(DEATH_BACKGROUND)
   do write(YOU_DIED)
+  do draw(Simple(RETRY_BUTTON))
+  do write(RETRY_TEXT)
 }

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -16,8 +16,19 @@ import src/utils
 import src/vec2d
 
 def main(): Unit = {
-  val canvas = createCanvas(CANVAS_WIDTH, CANVAS_HEIGHT)
-  val game = ref[GameState](START_GAME)
+  val canvasWidth = ref[Int](innerWidth())
+  val canvasHeight = ref[Int](innerHeight())
+  val canvas = createCanvas(canvasWidth.get, canvasHeight.get)
+
+  def screen[T] { f: () => T / Screen }: T = {
+    try { f() }
+    with Screen {
+      def width = resume(canvasWidth.get)
+      def height = resume(canvasHeight.get)
+    }
+  }
+
+  val game = screen { ref[GameState](startGame()) }
 
   val keysPressed = emptyMap[String, Bool]()
   val mousePos = ref[Vec2d](NULL_VECTOR)
@@ -31,6 +42,7 @@ def main(): Unit = {
   }
 
   def idleCallback(deadline: IdleDeadline): Unit = {
+    with screen;
     try {
       val dt = timeSinceLastFrame()
       if (game.get.player.isAlive) {
@@ -40,8 +52,9 @@ def main(): Unit = {
       } else {
         println(show(game.get.score))
         renderDeathScreen()
-        do draw(Simple(RETRY_BUTTON))
-        do write(RETRY_TEXT)
+        val (button, text) = retryButton()
+        do draw(Simple(button))
+        do write(text)
       }
     } with Canvas {
       def draw(drawable) = {
@@ -83,9 +96,6 @@ def main(): Unit = {
       def mousePos() = resume(mousePos.get)
     } with random {
       resume(random())
-    } with Screen {
-      def width = resume(CANVAS_WIDTH)
-      def height = resume(CANVAS_HEIGHT)
     }
     
     requestIdleCallback(idleCallback)
@@ -102,9 +112,11 @@ def main(): Unit = {
     mousePos.set(Vec2d(x, y))
   }
   def mouseDownHandler(event: Event): Unit = {
+    with screen;
     val leftButtonPressed = event.getButton() == 0
     if (leftButtonPressed) {
       val player = game.get.player
+      val (retryButton, _) = retryButton()
       if (player.isAlive()) {
         val playerCenter = player.drawable.getCenter()
         val gunAngle = angleClockwise(mousePos.get - playerCenter)
@@ -114,16 +126,25 @@ def main(): Unit = {
           Vec2d(1.0, 0.0).rotate(gunAngle)
         )
         game.map{g => g.addObject(bullet)}
-      } else if (mousePos.get.isInside(RETRY_BUTTON.toHitbox())) {
-        game.set(START_GAME)
+      } else if (mousePos.get.isInside(retryButton.toHitbox())) {
+        game.set(startGame())
       }
     }
+  }
+
+  def resizeHandler(event: Event): Unit = {
+    val newWidth = innerWidth()
+    val newHeight = innerHeight()
+    canvasWidth.set(newWidth)
+    canvasHeight.set(newHeight)
+    canvas.resize(newWidth, newHeight)
   }
 
   addEventListener(KEY_DOWN, pressedHandler)
   addEventListener(KEY_UP, releasedHandler)
   addEventListener(MOUSE_MOVE, mouseMoveHandler)
   addEventListener(MOUSE_DOWN, mouseDownHandler)
+  addEventListener(RESIZE, resizeHandler)
 
   requestIdleCallback(idleCallback)
 }

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -17,7 +17,9 @@ import src/vec2d
 
 def main(): Unit = {
   createCanvas(GAME_WIDTH, GAME_HEIGHT)
-  val ctx = ref[Context2D](resizeCanvas(windowWidth(), windowHeight()))
+  val displayedWidth = ref[Int](windowWidth())
+  val displayedHeight = ref[Int](windowHeight())
+  val ctx = ref[Context2D](resizeCanvas(displayedWidth.get, displayedHeight.get))
 
   def screen[T] { f: () => T / Screen }: T = {
     try { f() }
@@ -106,8 +108,10 @@ def main(): Unit = {
     keysPressed.update(event.getKey(), false)
 
   def mouseMoveHandler(event: Event): Unit = {
-    val x = event.getClientX()
-    val y = event.getClientY()
+    val xRatio = GAME_WIDTH.toDouble / displayedWidth.get.toDouble 
+    val yRatio = GAME_HEIGHT.toDouble / displayedHeight.get.toDouble
+    val x = event.getClientX() * xRatio
+    val y = event.getClientY() * yRatio
     mousePos.set(Vec2d(x, y))
   }
   def mouseDownHandler(event: Event): Unit = {
@@ -134,6 +138,8 @@ def main(): Unit = {
   def resizeHandler(event: Event): Unit = {
     val newWidth = windowWidth()
     val newHeight = windowHeight()
+    displayedWidth.set(newWidth)
+    displayedHeight.set(newHeight)
     ctx.set(resizeCanvas(newWidth, newHeight))
   }
 

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -17,8 +17,9 @@ import src/vec2d
 
 def main(): Unit = {
   createCanvas(GAME_WIDTH, GAME_HEIGHT)
-  val displayedWidth = ref[Int](windowWidth())
-  val displayedHeight = ref[Int](windowHeight())
+  val (dW, dH) = fittingSizes(windowWidth(), windowHeight()) 
+  val displayedWidth = ref[Int](dW)
+  val displayedHeight = ref[Int](dH)
   val ctx = ref[Context2D](resizeCanvas(displayedWidth.get, displayedHeight.get))
 
   val game = ref[GameState](START_GAME)
@@ -122,8 +123,7 @@ def main(): Unit = {
   }
 
   def resizeHandler(event: Event): Unit = {
-    val newWidth = windowWidth()
-    val newHeight = windowHeight()
+    val (newWidth, newHeight) = fittingSizes(windowWidth(), windowHeight())
     displayedWidth.set(newWidth)
     displayedHeight.set(newHeight)
     ctx.set(resizeCanvas(newWidth, newHeight))

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -16,15 +16,14 @@ import src/utils
 import src/vec2d
 
 def main(): Unit = {
-  val canvasWidth = ref[Int](innerWidth())
-  val canvasHeight = ref[Int](innerHeight())
-  val canvas = createCanvas(canvasWidth.get, canvasHeight.get)
+  createCanvas(GAME_WIDTH, GAME_HEIGHT)
+  val ctx = ref[Context2D](resizeCanvas(windowWidth(), windowHeight()))
 
   def screen[T] { f: () => T / Screen }: T = {
     try { f() }
     with Screen {
-      def width = resume(canvasWidth.get)
-      def height = resume(canvasHeight.get)
+      def width = resume(GAME_WIDTH)
+      def height = resume(GAME_HEIGHT)
     }
   }
 
@@ -60,22 +59,22 @@ def main(): Unit = {
       def draw(drawable) = {
         def drawSimple(d: SimpleDrawable): Unit = d match {
           case Rect(upperLeft, width, height, color) =>
-            canvas.drawRect(
+            ctx.get.drawRect(
               upperLeft.x, upperLeft.y, 
               width, height, show(color)
             )
           case Circle(center, radius, color) =>
-            canvas.drawCircle(center.x, center.y, radius, show(color))
+            ctx.get.drawCircle(center.x, center.y, radius, show(color))
         }
 
         def unwrapDraw(d: ManipulatedDrawable): Unit = d match {
           case Simple(inner) => drawSimple(inner)
           case Rotate(inner, rotation, relativeTo) =>
-            val oldMatrix = canvas.getTransform()
+            val oldMatrix = ctx.get.getTransform()
             val realRelative = relativeTo.getOrElse { inner.getCenter() }
-            canvas.setupRotation(rotation, realRelative.x, realRelative.y)
+            ctx.get.setupRotation(rotation, realRelative.x, realRelative.y)
             unwrapDraw(inner)
-            canvas.setTransform(oldMatrix)
+            ctx.get.setTransform(oldMatrix)
           case Compose(first, second) =>
             unwrapDraw(first); unwrapDraw(second)
         }
@@ -83,14 +82,14 @@ def main(): Unit = {
         resume(())
       }
       def write(text) = {
-        canvas.drawText(
+        ctx.get.drawText(
           text.text, text.position.x, text.position.y,
           show(text.fontSizePX) ++ "px " ++ show(text.fontType), 
           show(text.alignment), show(text.baseline), show(text.color)
         )
         resume(())
       }
-      def clear = { canvas.clear(); resume(()) }
+      def clear = { ctx.get.clear(); resume(()) }
     } with Input {
       def isPressed(key) = resume(keysPressed.get(key).getOrElse { false })
       def mousePos() = resume(mousePos.get)
@@ -133,11 +132,9 @@ def main(): Unit = {
   }
 
   def resizeHandler(event: Event): Unit = {
-    val newWidth = innerWidth()
-    val newHeight = innerHeight()
-    canvasWidth.set(newWidth)
-    canvasHeight.set(newHeight)
-    canvas.resize(newWidth, newHeight)
+    val newWidth = windowWidth()
+    val newHeight = windowHeight()
+    ctx.set(resizeCanvas(newWidth, newHeight))
   }
 
   addEventListener(KEY_DOWN, pressedHandler)

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -51,11 +51,13 @@ def main(): Unit = {
         def drawSimple(d: SimpleDrawable): Unit = d match {
           case Rect(upperLeft, width, height, color) =>
             ctx.get.drawRect(
-              upperLeft.x, upperLeft.y, 
-              width, height, show(color)
+              upperLeft.x.toInt, upperLeft.y.toInt, 
+              width.toInt, height.toInt, show(color)
             )
           case Circle(center, radius, color) =>
-            ctx.get.drawCircle(center.x, center.y, radius, show(color))
+            ctx.get.drawCircle(
+              center.x.toInt, center.y.toInt, radius.toInt, show(color)
+            )
         }
 
         def unwrapDraw(d: ManipulatedDrawable): Unit = d match {
@@ -63,7 +65,7 @@ def main(): Unit = {
           case Rotate(inner, rotation, relativeTo) =>
             val oldMatrix = ctx.get.getTransform()
             val realRelative = relativeTo.getOrElse { inner.getCenter() }
-            ctx.get.setupRotation(rotation, realRelative.x, realRelative.y)
+            ctx.get.setupRotation(rotation, realRelative.x.toInt, realRelative.y.toInt)
             unwrapDraw(inner)
             ctx.get.setTransform(oldMatrix)
           case Compose(first, second) =>
@@ -74,7 +76,7 @@ def main(): Unit = {
       }
       def write(text) = {
         ctx.get.drawText(
-          text.text, text.position.x, text.position.y,
+          text.text, text.position.x.toInt, text.position.y.toInt,
           show(text.fontSizePX) ++ "px " ++ show(text.fontType), 
           show(text.alignment), show(text.baseline), show(text.color)
         )

--- a/src/main.effekt
+++ b/src/main.effekt
@@ -21,15 +21,7 @@ def main(): Unit = {
   val displayedHeight = ref[Int](windowHeight())
   val ctx = ref[Context2D](resizeCanvas(displayedWidth.get, displayedHeight.get))
 
-  def screen[T] { f: () => T / Screen }: T = {
-    try { f() }
-    with Screen {
-      def width = resume(GAME_WIDTH)
-      def height = resume(GAME_HEIGHT)
-    }
-  }
-
-  val game = screen { ref[GameState](startGame()) }
+  val game = ref[GameState](START_GAME)
 
   val keysPressed = emptyMap[String, Bool]()
   val mousePos = ref[Vec2d](NULL_VECTOR)
@@ -43,7 +35,6 @@ def main(): Unit = {
   }
 
   def idleCallback(deadline: IdleDeadline): Unit = {
-    with screen;
     try {
       val dt = timeSinceLastFrame()
       if (game.get.player.isAlive) {
@@ -53,9 +44,6 @@ def main(): Unit = {
       } else {
         println(show(game.get.score))
         renderDeathScreen()
-        val (button, text) = retryButton()
-        do draw(Simple(button))
-        do write(text)
       }
     } with Canvas {
       def draw(drawable) = {
@@ -115,22 +103,20 @@ def main(): Unit = {
     mousePos.set(Vec2d(x, y))
   }
   def mouseDownHandler(event: Event): Unit = {
-    with screen;
     val leftButtonPressed = event.getButton() == 0
     if (leftButtonPressed) {
       val player = game.get.player
-      val (retryButton, _) = retryButton()
       if (player.isAlive()) {
         val playerCenter = player.drawable.getCenter()
         val gunAngle = angleClockwise(mousePos.get - playerCenter)
         val bulletDrawable = player.gun.changeColor(Black())
         val bullet = Bullet(
           Rotate(Simple(bulletDrawable), gunAngle, Some(playerCenter)),
-          Vec2d(1.0, 0.0).rotate(gunAngle)
+          Vec2d(BULLET_SPEED, 0.0).rotate(gunAngle)
         )
         game.map{g => g.addObject(bullet)}
-      } else if (mousePos.get.isInside(retryButton.toHitbox())) {
-        game.set(startGame())
+      } else if (mousePos.get.isInside(RETRY_BUTTON.toHitbox())) {
+        game.set(START_GAME)
       }
     }
   }

--- a/src/test/gameTest.effekt
+++ b/src/test/gameTest.effekt
@@ -24,12 +24,9 @@ def gameSuite() = suite("game") {
   val DUMMY_SCORE = Score(0, 0, 0)
   val DUMMYGAME = GameState(DUMMY_PLAYER, [], DUMMY_TIMERS, 0, DUMMY_SCORE)
 
-  def pseudoHandler { f: () => Unit / {Input, random, Screen} }: Unit = {
+  def pseudoHandler { f: () => Unit / {Input, random} }: Unit = {
     try { f() }
-    with Screen {
-      def width = resume(0)
-      def height = resume(0)
-    } with Input {
+    with Input {
       def isPressed(key) = resume(false)
       def mousePos() = resume(NULL_VECTOR)
     } with random { resume(0.0) }
@@ -108,7 +105,8 @@ def gameSuite() = suite("game") {
     val MISSING_HITBOX = Simple(Rect(Vec2d(80.0, 80.0), 10.0, 10.0, Black()))
     val MISSING_BULLET = Bullet(MISSING_HITBOX, Vec2d(3.0, 3.0))
 
-    val OUT_OF_RANGE_HITBOX = Simple(Rect(Vec2d(200.0, 200.0), 10.0, 10.0, Black()))
+    val OUT_OF_RANGE_HITBOX = 
+      Simple(Rect(fromInt(GAME_WIDTH + 10, GAME_HEIGHT + 10), 10.0, 10.0, Black()))
     val OUT_OF_RANGE = Bullet(OUT_OF_RANGE_HITBOX, Vec2d(2.0, 2.0))
 
     assertTrue(
@@ -121,14 +119,9 @@ def gameSuite() = suite("game") {
       "Bullet should not collide with non-overlapping zombie"
     )
     
-    val (remaining, dead, missed) = try {
-      shooting(
-        [MISSING_BULLET, SHOT_ZOMBIE, OUT_OF_RANGE, ALIVE, BULLET]
-      )
-    } with Screen {
-      def width() = resume(100)
-      def height() = resume(100)
-    }
+    val (remaining, dead, missed) = shooting(
+      [MISSING_BULLET, SHOT_ZOMBIE, OUT_OF_RANGE, ALIVE, BULLET]
+    )
 
     assert(dead, 1, "Shooting should signal that exactly one zombie died")
 

--- a/src/test/gameTest.effekt
+++ b/src/test/gameTest.effekt
@@ -2,6 +2,7 @@ module gameTest
 
 import test
 import mutable/map
+import src/game/constants
 import src/game/player
 import src/game/gametimer
 import src/game/game
@@ -26,8 +27,8 @@ def gameSuite() = suite("game") {
   def pseudoHandler { f: () => Unit / {Input, random, Screen} }: Unit = {
     try { f() }
     with Screen {
-      def width = resume(0.0)
-      def height = resume(0.0)
+      def width = resume(0)
+      def height = resume(0)
     } with Input {
       def isPressed(key) = resume(false)
       def mousePos() = resume(NULL_VECTOR)
@@ -125,8 +126,8 @@ def gameSuite() = suite("game") {
         [MISSING_BULLET, SHOT_ZOMBIE, OUT_OF_RANGE, ALIVE, BULLET]
       )
     } with Screen {
-      def width() = resume(100.0)
-      def height() = resume(100.0)
+      def width() = resume(100)
+      def height() = resume(100)
     }
 
     assert(dead, 1, "Shooting should signal that exactly one zombie died")


### PR DESCRIPTION
When the user resizes his window, the canvas gets resized as well while maintaining the aspect ratio. The logical width of the canvas does not change, only over css the displayed width and height. Sprites should not get blurry by zooming.